### PR TITLE
Fixing Image URL

### DIFF
--- a/2021/spring-ignite/intro-to-github/notes/adamsnetiker.md
+++ b/2021/spring-ignite/intro-to-github/notes/adamsnetiker.md
@@ -6,4 +6,4 @@ You can see some of the projects I'm working on by visiting [my repo](https://ww
 
 Here's a picture of a lit match to represent **Ignite**.
 <br><br>
-![Lit match](https://github.com/adam-snetiker/talkswithdrg/blob/main/2021/spring-ignite/intro-to-github/notes/ignite.jpg) 
+![Lit match](https://raw.githubusercontent.com/adam-snetiker/talkswithdrg/main/2021/spring-ignite/intro-to-github/notes/ignite.jpg) 


### PR DESCRIPTION
👋 @adam-snetiker 

After merging I realized the image url was not working properly. 

You can see in this PR that I added in the "raw-image" link instead of the link to it in your repo. You can this by right-clicking on the image in your repo and clicking "copy-image-link":  
![raw-link](https://user-images.githubusercontent.com/1314285/109894892-1b715f80-7c43-11eb-8d72-6b48546b73c1.jpg)

So you can see that the URL for the image is:  
`https://github.com/adam-snetiker/talkswithdrg/blob/main/2021/spring-ignite/intro-to-github/notes/ignite.jpg`

But when you right-click and copy-image-link you get:  
`https://github.com/adam-snetiker/talkswithdrg/blob/main/2021/spring-ignite/intro-to-github/notes/ignite.jpg?raw=true`  
or   
`https://raw.githubusercontent.com/adam-snetiker/talkswithdrg/main/2021/spring-ignite/intro-to-github/notes/ignite.jpg`

😄 